### PR TITLE
Bryce imports (and small fix)

### DIFF
--- a/canvas_handler.py
+++ b/canvas_handler.py
@@ -1,12 +1,10 @@
 import re
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple
 
 import dateutil.parser.isoparser
 import discord
-import pytz
 from bs4 import BeautifulSoup
-from canvasapi.assignment import Assignment
 from canvasapi.canvas import Canvas
 from canvasapi.course import Course
 from canvasapi.paginated_list import PaginatedList

--- a/commands.py
+++ b/commands.py
@@ -5,18 +5,15 @@ import mimetypes
 import os
 import random
 import re
-from datetime import datetime, timedelta
+from datetime import datetime
 from fractions import Fraction
 from io import BytesIO
-from typing import List, Optional
+from typing import Optional
 
-import dateutil.parser.isoparser
 import discord
 import pytz
 import requests
 import webcolors
-from bs4 import BeautifulSoup
-from canvasapi import Canvas
 from discord.ext import commands
 from dotenv import load_dotenv
 from googletrans import Translator, constants

--- a/cs221bot.py
+++ b/cs221bot.py
@@ -3,10 +3,8 @@ import json
 import os
 import random
 import re
-import time
 import traceback
 from datetime import datetime
-from os.path import isfile, join
 
 import discord
 from discord.ext import commands

--- a/cs221bot.py
+++ b/cs221bot.py
@@ -190,9 +190,9 @@ async def on_command_error(ctx, error):
 
         # prints full traceback
         try:
-            await ctx.send("```" + "".join(traceback.format_exception(etype, error, trace, 999)) + "```".replace("C:\\Users\\William\\anaconda3\\lib\\site-packages\\", "").replace("D:\\my file of stuff\\cs221bot\\", ""))
+            await ctx.send(("```" + "".join(traceback.format_exception(etype, error, trace, 999)) + "```").replace("C:\\Users\\William\\anaconda3\\lib\\site-packages\\", "").replace("D:\\my file of stuff\\cs221bot\\", ""))
         except:
-            print("```" + "".join(traceback.format_exception(etype, error, trace, 999)) + "```".replace("C:\\Users\\William\\anaconda3\\lib\\site-packages\\", "").replace("D:\\my file of stuff\\cs221bot\\", ""))
+            print(("```" + "".join(traceback.format_exception(etype, error, trace, 999)) + "```").replace("C:\\Users\\William\\anaconda3\\lib\\site-packages\\", "").replace("D:\\my file of stuff\\cs221bot\\", ""))
 
 bot.loop.create_task(Main.track_inotes(bot.get_cog("Main")))
 bot.loop.create_task(Main.send_pupdate(bot.get_cog("Main")))


### PR DESCRIPTION
Fixed that error message so that it replaces properly. I also ran an optimize imports just because I can. There is probably a better way to do it using [this SO question](https://stackoverflow.com/questions/37056981/python3-dont-show-full-directory-path-on-error-message) but for only one use, it does not really matter.

This will be my final trivial pull request. I am going to manually review the code next.