### PR TITLE
Fix Piazza issue

### DIFF
--- a/cogs/piazza.py
+++ b/cogs/piazza.py
@@ -205,7 +205,10 @@ class Piazza(commands.Cog):
     async def send_pupdate(self):
         while True:
             await self.send_piazza_posts(True)
-            await asyncio.sleep(60 * 60 * 24)
+            if not self.bot.d_handler.piazza_handler:
+                await asyncio.sleep(60)
+            else:
+                await asyncio.sleep(60 * 60 * 24)
 
     async def send_piazza_posts(self, wait: bool):
         if not self.bot.d_handler.piazza_handler:

--- a/cogs/piazza.py
+++ b/cogs/piazza.py
@@ -254,8 +254,9 @@ class Piazza(commands.Cog):
                     for chnl in self.bot.d_handler.piazza_handler.channels:
                         channel = self.bot.get_channel(chnl)
                         await channel.send(response)
-
-            await asyncio.sleep(60 * 60 * 5)
+                await asyncio.sleep(60 * 60 * 5)
+            else:
+                await asyncio.sleep(60)
 
     @staticmethod
     def piazza_start(self):


### PR DESCRIPTION
Piazza would not be initialized initially so it would try to schedule the post to be sent, fail, then wait until the next day to try again. What this means is that anytime that the bot is restarted, it will not post the Piazza posts until the day after. This fixes these issues so that it will only wait 60 seconds if Piazza is not initialized so that it will be able to schedule as soon as Piazza is initialized rather than the next day.