### PR TITLE
Improvements to Canvas code

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ You can install all of them using `pip install -r requirements.txt`.
 Start the bot by using `python3 cs221bot.py`. 
 View the list of commands by typing `!help` in a server where the bot is in.
 
-If you are tracking non-public Canvas courses with the bot, you will need to set a Canvas-generated user token as
-the environmental variable `CANVAS_API_KEY` in the `.env` file. When starting the bot, you need to use the `-t` flag,
-i.e. run the command `python3 cs221bot.py -t`.
+The bot's Canvas module-tracking functionality only notifies you of new *published* modules by default.
+If you want the bot to notify you when it sees a new *unpublished* module, run the bot with the
+`--cnu` flag, i.e. run `python3 cs221bot.py --cnu`. You need to have access to unpublished modules, though.

--- a/cogs/canvas.py
+++ b/cogs/canvas.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import operator
 import os
 import re
@@ -10,6 +11,7 @@ from typing import List, Optional, Set, TextIO, Tuple, Union
 import canvasapi
 import discord
 from canvasapi.module import Module, ModuleItem
+from canvasapi.paginated_list import PaginatedList
 from discord.ext import commands
 from dotenv import load_dotenv
 
@@ -355,8 +357,12 @@ class Canvas(commands.Cog):
         For every folder in handler.canvas_handler.COURSES_DIRECTORY (abbreviated as CDIR) we will:
         - get the modules for the Canvas course with ID that matches the folder name
         - compare the modules we retrieved with the modules found in CDIR/{course_id}/modules.txt
-        - send the names of any modules not in the file to all channels in CDIR/{course_id}/watchers.txt
+        - send the names of any new modules (i.e. modules that are not in modules.txt) to all channels 
+          in CDIR/{course_id}/watchers.txt
         - update CDIR/{course_id}/modules.txt with the modules we retrieved from Canvas
+
+        NOTE: the Canvas API distinguishes between a Module and a ModuleItem. In our documentation, though,
+        the word "module" can refer to both; we do not distinguish between the two types.
         """
 
         def get_field_value(module: Union[Module, ModuleItem]) -> str:
@@ -381,95 +387,83 @@ class Canvas(commands.Cog):
 
             return field
 
-        def update_embed(embed: discord.Embed, module: Union[Module, ModuleItem],
-                         num_fields: int, embed_list: List[discord.Embed]) -> Tuple[discord.Embed, int]:
+        def update_embed(embed: discord.Embed, module: Union[Module, ModuleItem], embed_list: List[discord.Embed]):
             """
             Adds a field to embed containing information about given module. The field includes the module's name or title,
             as well as a hyperlink to the module if one exists.
 
-            If the module's identifier (its name or title) has over MAX_MODULE_IDENTIFIER_LENGTH characters, we truncate the identifier
-            and append an ellipsis (...) so that it has MAX_MODULE_IDENTIFIER_LENGTH characters.
+            If the module's identifier (its name or title) has over MAX_IDENTIFIER_LENGTH characters, we truncate the identifier
+            and append an ellipsis (...) so that the length does not exceed the maximum.
 
-            The embed object that is passed in must have at most 24 fields. Use the parameter `num_fields` to specify the number
-            of fields the embed object has.
+            The embed object that is passed in must have at most 24 fields.
 
-            The embed object is appended to embed_list in two cases:
-            - if adding the new field will cause the embed to exceed EMBED_CHAR_LIMIT characters in length, the embed is appended to embed_list first.
-                Then, we create a new embed and add the field to the new embed.
-            - if the embed has 25 fields after adding the new field, we append embed to embed_list.
-
-            Note that Python stores references in lists -- hence, modifying the content of the embed variable after calling
-            this function will modify embed_list if embed was added to embed_list.
-
-            This function returns a tuple (embed, num_fields) containing the updated values of embed and num_fields.
-
-            NOTE: changes to embed_list will persist outside this function, but changes to embed and num_fields
-            may not be reflected outside this function. The caller should update (reassign) the values that were passed
-            in to embed and num_fields using the tuple returned by this function. A reassignment of embed will not
-            change the contents of embed_list.
+            A deep copy of the embed object is appended to embed_list in two cases:
+            - if adding the new field will cause the embed to exceed EMBED_CHAR_LIMIT characters in length
+            - if the embed has 25 fields after adding the new field
+            In both cases, we clear all of the original embed's fields after adding the embed copy to embed_list.
+            
+            NOTE: changes to embed and embed_list will persist outside this function.
             """
 
             field_value = get_field_value(module)
 
             # Note: 11 is the length of the string "Module Item"
             if 11 + len(field_value) + len(embed) > EMBED_CHAR_LIMIT:
-                embed_list.append(embed)
-                embed = discord.Embed(title=f"New modules for {course.name} (continued):", color=CANVAS_COLOR)
-                embed.set_thumbnail(url=CANVAS_THUMBNAIL_URL)
-                num_fields = 0
+                embed_list.append(copy.deepcopy(embed))
+                embed.clear_fields()
+                embed.title = f"New modules found for {course.name} (continued):"
 
             if isinstance(module, canvasapi.module.Module):
                 embed.add_field(name="Module", value=field_value, inline=False)
             else:
                 embed.add_field(name="Module Item", value=field_value, inline=False)
 
-            num_fields += 1
+            if len(embed.fields) == 25:
+                embed_list.append(copy.deepcopy(embed))
+                embed.clear_fields()
+                embed.title = f"New modules found for {course.name} (continued):"
 
-            if num_fields == 25:
+        def get_all_modules(course: canvasapi.course.Course) -> List[Union[Module, ModuleItem]]:
+            """
+            Returns a list of all modules for the given course.
+            """
+
+            all_modules = []
+
+            for module in course.get_modules():
+                all_modules.append(module)
+                    
+                for item in module.get_module_items():
+                        all_modules.append(item)
+            
+            return all_modules
+
+        def write_modules(file_path: str, modules: List[Union[Module, ModuleItem]]):
+            """
+            Stores the ID of all modules in file with given path.
+            """
+
+            with open(file_path, "w") as f:
+                for module in modules:
+                    f.write(str(module.id) + "\n")
+        
+        def get_embeds(modules: List[Union[Module, ModuleItem]]) -> List[discord.Embed]:
+            """
+            Returns a list of Discord embeds to send to live channels.
+            """
+
+            embed = discord.Embed(title=f"New modules found for {course.name}:", color=CANVAS_COLOR)
+            embed.set_thumbnail(url=CANVAS_THUMBNAIL_URL)
+            
+            embed_list = []
+            
+            for module in modules:
+                update_embed(embed, module, embed_list)
+            
+            if len(embed.fields) != 0:
                 embed_list.append(embed)
-                embed = discord.Embed(title=f"New modules for {course.name} (continued):", color=CANVAS_COLOR)
-                embed.set_thumbnail(url=CANVAS_THUMBNAIL_URL)
-                num_fields = 0
-
-            return embed, num_fields
-
-        def handle_module(module: Union[Module, ModuleItem], modules_file: TextIO, existing_modules: Set[str],
-                          curr_embed: discord.Embed, curr_embed_num_fields: int,
-                          embed_list: List[discord.Embed]) -> Tuple[discord.Embed, int]:
-            """
-            Writes given module or module item to modules_file. This function assumes that:
-            - modules_file has already been opened in write/append mode.
-            - module has the "name" attribute if it is an instance of canvasapi.module.Module.
-            - module has the "html_url" attribute or the "title" attribute if it is an instance of canvasapi.module.ModuleItem.
-
-            existing_modules contains contents of the pre-existing modules file (or is empty if the modules file has just been created)
-
-            This function updates curr_embed, curr_embed_num_fields, and embed_list depending on whether existing_modules already
-            knows about the given module item.
-
-            The function returns a tuple (curr_embed, curr_embed_num_fields) containing the updated values of curr_embed and curr_embed_num_fields.
-
-            NOTE: changes to embed_list will persist outside this function, but changes to curr_embed and curr_embed_num_fields may not be
-            reflected outside this function. The caller should update the values that were passed in to curr_embed and curr_embed_num_fields
-            using the tuple returned by this function.
-            """
-
-            if isinstance(module, canvasapi.module.Module):
-                to_write = module.name
-            else:
-                if hasattr(module, "html_url"):
-                    to_write = module.html_url
-                else:
-                    to_write = module.title
-
-            modules_file.write(to_write + "\n")
-
-            if to_write not in existing_modules:
-                embed_num_fields_tuple = update_embed(curr_embed, module, curr_embed_num_fields, embed_list)
-                curr_embed = embed_num_fields_tuple[0]
-                curr_embed_num_fields = embed_num_fields_tuple[1]
-
-            return curr_embed, curr_embed_num_fields
+            
+            return embed_list
 
         if os.path.exists(util.canvas_handler.COURSES_DIRECTORY):
             courses = [name for name in os.listdir(util.canvas_handler.COURSES_DIRECTORY)]
@@ -490,27 +484,11 @@ class Canvas(commands.Cog):
                         with open(modules_file, "r") as m:
                             existing_modules = set(m.read().splitlines())
 
-                        embeds_to_send = []
+                        all_modules = get_all_modules(course)
+                        write_modules(modules_file, all_modules)
+                        differences = list(filter(lambda module: str(module.id) not in existing_modules, all_modules))
 
-                        curr_embed = discord.Embed(title=f"New modules found for {course.name}:", color=CANVAS_COLOR)
-                        curr_embed.set_thumbnail(url=CANVAS_THUMBNAIL_URL)
-                        curr_num_fields = 0
-
-                        with open(modules_file, "w") as m:
-                            for module in course.get_modules():
-                                if hasattr(module, "name"):
-                                    embed_num_fields_tuple = handle_module(module, m, existing_modules, curr_embed, curr_num_fields, embeds_to_send)
-                                    curr_embed = embed_num_fields_tuple[0]
-                                    curr_num_fields = embed_num_fields_tuple[1]
-
-                                    for item in module.get_module_items():
-                                        if hasattr(item, "title"):
-                                            embed_num_fields_tuple = handle_module(item, m, existing_modules, curr_embed, curr_num_fields, embeds_to_send)
-                                            curr_embed = embed_num_fields_tuple[0]
-                                            curr_num_fields = embed_num_fields_tuple[1]
-
-                        if curr_num_fields:
-                            embeds_to_send.append(curr_embed)
+                        embeds_to_send = get_embeds(differences)
 
                         if embeds_to_send:
                             with open(watchers_file, "r") as w:

--- a/cogs/canvas.py
+++ b/cogs/canvas.py
@@ -232,8 +232,8 @@ class Canvas(commands.Cog):
             since = "2-week"
             course_ids = args
 
-        # TODO: Issue: this causes private messages to be sent as announcements.
-        for data in c_handler.get_course_stream_ch(since, course_ids, CANVAS_API_URL, CANVAS_API_KEY):
+        # TODO: this is broken right now. Replacing "" with CANVAS_API_KEY causes private messages to be sent as announcements.
+        for data in c_handler.get_course_stream_ch(since, course_ids, CANVAS_API_URL, ""):
             embed_var = discord.Embed(title=data[2], url=data[3], description=data[4], color=CANVAS_COLOR)
             embed_var.set_author(name=data[0], url=data[1])
             embed_var.set_thumbnail(url=CANVAS_THUMBNAIL_URL)
@@ -281,8 +281,8 @@ class Canvas(commands.Cog):
                     since = ch.timings[str(c.id)]
                     since = re.sub(r"\s", "-", since)
                     
-                    # TODO: Issue: this causes private messages to be sent as announcements.
-                    data_list = ch.get_course_stream_ch(since, (str(c.id),), CANVAS_API_URL, CANVAS_API_KEY)
+                    # TODO: this is broken right now. Replacing "" with CANVAS_API_KEY causes private messages to be sent as announcements.
+                    data_list = ch.get_course_stream_ch(since, (str(c.id),), CANVAS_API_URL, "")
 
                     for data in data_list:
                         embed_var = discord.Embed(title=data[2], url=data[3], description=data[4], color=CANVAS_COLOR)

--- a/cs221bot.py
+++ b/cs221bot.py
@@ -26,8 +26,8 @@ CS221BOT_KEY = os.getenv("CS221BOT_KEY")
 bot = commands.Bot(command_prefix="!", help_command=None, intents=discord.Intents.all())
 
 parser = argparse.ArgumentParser(description="Run CS221Bot")
-parser.add_argument("-t", dest="testing_mode", action="store_const", const=True, default=False,
-                    help="Run the bot in testing mode, allowing you to track non-public Canvas courses")
+parser.add_argument("--cnu", dest="notify_unpublished", action="store_true",
+                    help="Allow the bot to send notifications about unpublished Canvas modules (if you have access) as well as published ones.")
 args = parser.parse_args()
 
 
@@ -170,12 +170,11 @@ if __name__ == "__main__":
     bot.loadJSON = loadJSON
     bot.writeJSON = writeJSON
 
-    # The real Canvas API key (i.e. the one stored in the .env file) is required for Canvas
-    # courses without public access. However, the CPSC 221 course is accessible to the public.
-    # Since we only want to notify users about CPSC 221 assignments that are *publicly* available,
-    # we use the empty placeholder "" instead of the real Canvas API key when running in production.
-    # The -t flag is used in testing to indicate that we want to use the real Canvas API key.
-    bot.canvas_api_key = os.getenv("CANVAS_API_KEY") if args.testing_mode else ""
+    # True if the bot should send notifications about new *unpublished* modules on Canvas; False otherwise.
+    # This only matters if the host of the bot has access to unpublished modules. If the host does
+    # not have access, then the bot won't know about any unpublished modules and won't send any info
+    # about them anyway.
+    bot.notify_unpublished = args.notify_unpublished
 
     for extension in filter(lambda f: isfile(join("cogs", f)) and f != "__init__.py", os.listdir("cogs")):
         bot.load_extension(f"cogs.{extension[:-3]}")

--- a/util/canvas_handler.py
+++ b/util/canvas_handler.py
@@ -295,27 +295,27 @@ class CanvasHandler(Canvas):
         course_ids = self._ids_converter(course_ids_str)
         course_stream_list = tuple(get_course_stream(c.id, base_url, access_token) for c in self.courses if (not course_ids) or c.id in course_ids)
         data_list = []
-        
-        for item in (i for c_s in course_stream_list for i in c_s if i['type'] == "Conversation"):
-            course = self.get_course(item["course_id"])
 
-            course_url = get_course_url(course.id, base_url)
-            title = "Announcement: " + item["title"]
-            short_desc = "\n".join(item["latest_messages"][0]["message"].split("\n")[:4])
-            ctime_iso = item["created_at"]
+        for stream_iter in map(iter, course_stream_list):
+            for item in filter(lambda i: i['type'] == "Conversation", stream_iter):
+                course = self.get_course(item["course_id"])
+                course_url = get_course_url(course.id, base_url)
+                title = "Announcement: " + item["title"]
+                short_desc = "\n".join(item["latest_messages"][0]["message"].split("\n")[:4])
+                ctime_iso = item["created_at"]
 
-            if ctime_iso is None:
-                ctime_text = "No info"
-            else:
-                time_shift = datetime.now() - datetime.utcnow()
-                ctime_iso_parsed = (dateutil.parser.isoparse(ctime_iso) + time_shift).replace(tzinfo=None)
-                ctime_timedelta = ctime_iso_parsed - datetime.now()
-                if since and ctime_timedelta <= -self._make_timedelta(since):
-                    break
+                if ctime_iso is None:
+                    ctime_text = "No info"
+                else:
+                    time_shift = datetime.now() - datetime.utcnow()
+                    ctime_iso_parsed = (dateutil.parser.isoparse(ctime_iso) + time_shift).replace(tzinfo=None)
+                    ctime_timedelta = ctime_iso_parsed - datetime.now()
+                    if since and ctime_timedelta <= -self._make_timedelta(since):
+                        break
 
-                ctime_text = ctime_iso_parsed.strftime("%Y-%m-%d %H:%M:%S")
+                    ctime_text = ctime_iso_parsed.strftime("%Y-%m-%d %H:%M:%S")
 
-            data_list.append([course.name, course_url, title, item["html_url"], short_desc, ctime_text, course.id])
+                data_list.append([course.name, course_url, title, item["html_url"], short_desc, ctime_text, course.id])
 
         return data_list
 

--- a/util/canvas_handler.py
+++ b/util/canvas_handler.py
@@ -7,8 +7,10 @@ from typing import Dict, List, Optional, Set, Tuple
 import dateutil.parser.isoparser
 import discord
 from bs4 import BeautifulSoup
+from canvasapi.assignment import Assignment
 from canvasapi.canvas import Canvas
 from canvasapi.course import Course
+from canvasapi.paginated_list import PaginatedList
 
 from util import create_file
 from util.canvas_api_extension import get_course_stream, get_course_url
@@ -266,7 +268,7 @@ class CanvasHandler(Canvas):
                 if channel_id not in ids_to_remove:
                     f.write(channel_id)
 
-    def get_course_stream_ch(self, since: Optional[str], course_ids_str: Tuple[str, ...], base_url, access_token) -> List[List[str]]:
+    def get_course_stream_ch(self, since: Optional[str], course_ids_str: Tuple[str, ...], base_url: str, access_token: str) -> List[List[str]]:
         """
         Gets announcements for course(s)
 
@@ -293,9 +295,7 @@ class CanvasHandler(Canvas):
         course_ids = self._ids_converter(course_ids_str)
         course_stream_list = tuple(get_course_stream(c.id, base_url, access_token) for c in self.courses if (not course_ids) or c.id in course_ids)
         data_list = []
-
-        url = "https://canvas.ubc.ca/conversations?#filter=type=inbox&course=course_53540"
-
+        
         for item in (i for c_s in course_stream_list for i in c_s if i['type'] == "Conversation"):
             course = self.get_course(item["course_id"])
 
@@ -315,7 +315,7 @@ class CanvasHandler(Canvas):
 
                 ctime_text = ctime_iso_parsed.strftime("%Y-%m-%d %H:%M:%S")
 
-            data_list.append([course.name, course_url, title, url, short_desc, ctime_text, course.id])
+            data_list.append([course.name, course_url, title, item["html_url"], short_desc, ctime_text, course.id])
 
         return data_list
 
@@ -341,20 +341,20 @@ class CanvasHandler(Canvas):
         """
 
         course_ids = self._ids_converter(course_ids_str)
-        courses_assignments = [[c, c.get_assignments()] for c in self.courses if not course_ids or c.id in course_ids]
+        courses_assignments = {c: c.get_assignments() for c in self.courses if not course_ids or c.id in course_ids}
 
         return self._get_assignment_data(due, courses_assignments, base_url)
 
-    def _get_assignment_data(self, due: Optional[str], courses_assignments, base_url: str) -> List[List[str]]:
+    def _get_assignment_data(self, due: Optional[str], courses_assignments: Dict[Course, PaginatedList], base_url: str) -> List[List[str]]:
         """
-        Formats all courses assignments as separate assignments"
+        Formats all courses assignments as separate assignments
 
         Parameters
         ----------
         due : `None or str`
             Date/Time from due date of assignments
 
-        courses_assignments : `List[canvasapi.Course, PaginatedList[canvasapi.Assignment]]`
+        courses_assignments : `Dict[Course, PaginatedList of Assignments]`
             List of courses and their assignments
 
         base_url : `str`
@@ -368,12 +368,11 @@ class CanvasHandler(Canvas):
 
         data_list = []
 
-        for course_assignments in courses_assignments:
-            course = course_assignments[0]
+        for course, assignments in courses_assignments.items():
             course_name = course.name
             course_url = get_course_url(course.id, base_url)
 
-            for assignment in course_assignments[1]:
+            for assignment in filter(lambda asgn: asgn.published, assignments):
                 ass_id = assignment.__getattribute__("id")
                 title = "Assignment: " + assignment.__getattribute__("name")
                 url = assignment.__getattribute__("html_url")

--- a/util/create_file.py
+++ b/util/create_file.py
@@ -7,6 +7,7 @@ def create_file_if_not_exists(file_path):
     Creates file with given path (as str) if the file does not already exist.
     All required directories are created, too.
     """
+    
     pathlib.Path(os.path.dirname(file_path)).mkdir(parents=True, exist_ok=True)
     with open(file_path, 'a'):
         pass


### PR DESCRIPTION
## Summary
- rewrote the gigantic function `check_modules` in `canvas.py` to be less gigantic.
- made progress towards eliminating the usage of `""` instead of `CANVAS_API_KEY`. We can now use the bot to track modules and assignments in non-public Canvas courses. Even if CPSC 221 goes private, we'll be fine. By default, the bot will now only notify us about published modules and assignments.
- replaced the `-t` flag with `--cnu` in the command line arguments. (cnu stands for "**C**anvas **n**otify **u**npublished"). Running the bot with the `--cnu` flag causes the bot to send notifications about unpublished Canvas modules (not unpublished Canvas assignments, however). This might be useful if a TA (with access to unpublished modules) wants to use this bot for themselves, but ultimately it's not really important.

## Issues
- The bot's announcement-notification functionality is broken. It always has been, but I just discovered the issue today. I put two "TODO" comments in `canvas.py` indicating where the issue is. Replacing `""` with `CANVAS_API_KEY` causes private messages to be sent as announcements, so I did not do the replacement. However, that means the command `!annc` will result in `canvasapi.exceptions.InvalidAccessToken` being raised. See the `#bot-commands` channel in Discord for further discussion of this issue.