### PR TITLE
Fix Canvas Handlers not being reloaded properly on `!reload`

### DIFF
--- a/cogs/meta.py
+++ b/cogs/meta.py
@@ -69,7 +69,14 @@ class Meta(commands.Cog):
 
             await reload_msg.edit(content=f"{extension} module reloaded.")
 
+        await startup_tasks(self.bot)
         await ctx.send("Done")
+
+
+async def startup_tasks(bot: commands.Bot) -> None:
+    await bot.wait_until_ready()
+    bot.get_cog("Canvas").canvas_init()
+    bot.get_cog("Piazza").piazza_start()
 
 
 def setup(bot: commands.Bot) -> None:

--- a/cs221bot.py
+++ b/cs221bot.py
@@ -10,6 +10,7 @@ import discord
 from discord.ext import commands
 from dotenv import load_dotenv
 
+import cogs.meta
 from util.badargs import BadArgs
 
 CANVAS_COLOR = 0xe13f2b
@@ -52,14 +53,9 @@ async def status_task() -> None:
         await asyncio.sleep(30)
 
 
-def startup() -> None:
-    bot.get_cog("Canvas").canvas_init()
-    bot.get_cog("Piazza").piazza_start()
-
-
 @bot.event
 async def on_ready() -> None:
-    startup()
+    await cogs.meta.startup_tasks(bot)
     print("Logged in successfully")
     bot.loop.create_task(status_task())
     bot.loop.create_task(bot.get_cog("Piazza").send_pupdate())


### PR DESCRIPTION
Previously, when I do `!reload` and then `!live`, the bot says that a Canvas Handler does not exist. As a result, courses stop being tracked when the bot is reloaded. This PR fixes the issue.